### PR TITLE
Get rid of setEval names

### DIFF
--- a/lib/forest-core.js
+++ b/lib/forest-core.js
@@ -603,7 +603,7 @@
 
   var evaluators = {};
 
-  function setEvaluator(name, evaluator) {
+  function setEvaluator(evaluator, name) {
     evaluators[name] = evaluator;
   }
 

--- a/src/forest-common.jsx
+++ b/src/forest-common.jsx
@@ -95,8 +95,8 @@ export default class ForestCommon extends Component {
     return core.spawnObject(o);
   }
 
-  static setEvaluator(name, evaluator){
-    return core.setEvaluator(name, evaluator)
+  static setEvaluator(evaluator, name = evaluator.name) {
+    return core.setEvaluator(evaluator, name);
   }
 
   static runEvaluator(uid, params){

--- a/src/forest-core.js
+++ b/src/forest-core.js
@@ -468,7 +468,7 @@ function runEvaluator(uid, params){
 
 const evaluators = {}
 
-function setEvaluator(name, evaluator){
+function setEvaluator(evaluator, name){
   evaluators[name]=evaluator;
 }
 


### PR DESCRIPTION
This could possibly be a solution for the repetitive setEvaluator naming issue?