### PR TITLE
onClick and onLongPress extra functionality added

### DIFF
--- a/src/forest-common.jsx
+++ b/src/forest-common.jsx
@@ -192,7 +192,18 @@ class ForestWidget extends Component {
   getAndroidButtonProps = () => ({
     onPressIn: () => this.onChange(true),
     onPressOut: () => this.onChange(false),
-    onLongPress: () => this.onChange(true),
+    onPress: () => {
+      this.props.onChange(`${this.props.name}-clicked`, true);
+      setTimeout(()=>{
+        this.props.onChange(`${this.props.name}-clicked`, false);
+      }, 250);
+    },
+    onLongPress: () => {
+      this.props.onChange(`${this.props.name}-held`, true);
+      setTimeout(()=>{
+        this.props.onChange(`${this.props.name}-held`, false);
+      },250);
+    },
   });
 
   getAllProps = () => ({

--- a/src/forest-common.jsx
+++ b/src/forest-common.jsx
@@ -187,6 +187,12 @@ class ForestWidget extends Component {
   getWebButtonProps = () => ({
     onMouseDown: () => this.onChange(true),
     onMouseUp: () => this.onChange(false),
+    onClick: () => {
+      this.props.onChange(`${this.props.name}-clicked`, true);
+      setTimeout(()=>{
+        this.props.onChange(`${this.props.name}-clicked`, false);
+      }, 250);
+    },
   });
 
   getAndroidButtonProps = () => ({


### PR DESCRIPTION
    object('user-state.zigbeegateway-onboarding-clicked?') && { next: object('subs.zigbeegateway-onboarding') },

appends '-clicked' and '-held' to name 
