### PR TITLE
 Regex for non-deltas

### DIFF
--- a/src/forest-core.js
+++ b/src/forest-core.js
@@ -368,10 +368,10 @@ function regexAwareSplit(path){
   return pathbits;
 }
 
-function checkRegex(pattern, target){
+function checkRegex(regex, target){
   regexMatches.length = 0;
   for(let p in target){
-    const m2 = p.match(pattern[1]);
+    const m2 = p.match(regex[1]);
     if(!m2) continue;
     const match = m2[(m2.length > 1)? 1: 0];
     regexMatches.push({ value: target[p], match });


### PR DESCRIPTION
regex to return a list of matches for non delta objects

for example: 
```
eval(){
  return [
   object('user-state.delete-clicked?')  && processDelete(object('user-state./.+?-selected/), object('@$1')),
  ]
}
```
